### PR TITLE
Fixes #1 -- Add Vagrant+Packer based automated Pi OS img build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vagrant
+.packer.d
+packer_cache
+*.img

--- a/README-imgbuild.md
+++ b/README-imgbuild.md
@@ -1,0 +1,47 @@
+## Building a Raspberry Pi OS image
+
+This process creates an SD card image, bootstrapping it with our custom configuration.
+It's intended to eventually be the method that we create SD cards that would
+ship with the pitrex.
+
+The process uses Hashicorp Vagrant to automate a linux VM that then calls
+Hashicorp Packer with the Raspberry Pi OS builder from 
+https://github.com/solo-io/packer-builder-arm-image
+
+For now the image isn't really suitable for end users - we need some kind of
+menu system, and a likely a way of setting wifi details via this menu. Right
+now though, it does allow pitrex devs to build their own custom image, and I'm
+hoping encourage more work in this area.
+
+If you have any questions, please reach out to Mike Pountney on the pitrex-dev
+mailing list.
+
+## Procedure
+
+### Install Vagrant
+
+See https://www.vagrantup.com/downloads
+
+### Set environment for Wifi/SSH setup:
+
+   export WIFI_NAME={your wifi ssid}
+   export WIFI_PASS={your wifi password}
+
+   # optional, so you can log in as pi without a password
+   export SSH_PUBKEY={your ssh public key}
+
+
+### Initial provisioning
+
+   vagrant up
+
+### Recreating the image
+
+   vagrant provision --provision-with build-image
+
+
+### Burn image!
+
+This will create an image that can be burned to a SD card:
+
+   output-arm-image.img

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/focal64"
+  config.vm.synced_folder "./", "/vagrant", disabled: false
+  config.vm.provision "build-env", type: "shell",
+    :path => "build/vagrant/provision-build-env.sh",
+    privileged: false
+  config.vm.provision "packer-builder-arm-image", type: "shell",
+    :path => "build/vagrant/provision-packer-builder-arm-image.sh",
+    privileged: false,
+    env: {"GIT_CLONE_URL" => ENV["GIT_CLONE_URL"]}
+  config.vm.provision "build-image", type: "shell",
+    :path => "build/vagrant/provision-build-image.sh",
+    privileged: false,
+    env: {
+      "PACKERFILE" => ENV["PACKERFILE"],
+      "WIFI_NAME"  => ENV["WIFI_NAME"],
+      "WIFI_PASS"  => ENV["WIFI_PASS"],
+      "SSH_PUBKEY" => ENV["SSH_PUBKEY"]
+    }
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,8 +16,5 @@ Vagrant.configure("2") do |config|
     privileged: false,
     env: {
       "PACKERFILE" => ENV["PACKERFILE"],
-      "WIFI_NAME"  => ENV["WIFI_NAME"],
-      "WIFI_PASS"  => ENV["WIFI_PASS"],
-      "SSH_PUBKEY" => ENV["SSH_PUBKEY"]
     }
 end

--- a/build/packer/pitrex-linux.json
+++ b/build/packer/pitrex-linux.json
@@ -3,6 +3,7 @@
     "wifi_name":      null,
     "wifi_password":  null,
     "ssh_pubkey":     "",
+    "pitrex_git_url": "https://github.com/gtoal/pitrex.git",
     "home":           "{{env `HOME`}}"
   },
   "builders": [
@@ -48,6 +49,33 @@
       "type": "shell",
       "execute_command": "chmod +x {{ .Path }}; sudo {{ .Path }} -y -keephdmi",
       "script": "/vagrant/pitrex-config.sh"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "echo 'installing pitrex build env'",
+        "apt-get install -y gcc-arm-none-eabi git-core libsdl2-dev libsdl2-2.0 libsdl2-mixer-2.0-0 libsdl2-mixer-dev alsa-oss locate",
+        "echo DONE"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "echo 'installing pitrex src'",
+        "install -d -o pi -g pi -m 755 /home/pi/src",
+        "cd /home/pi/src",
+        "sudo -u pi git clone {{ user `pitrex_git_url` }}",
+        "echo DONE"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "echo 'building pitrex'",
+        "cd /home/pi/src/pitrex",
+        "#TODO sudo -u pi make -f Makefile.raspbian",
+        "echo DONE"
+      ]
     }
   ]
 }

--- a/build/packer/pitrex-linux.json
+++ b/build/packer/pitrex-linux.json
@@ -1,0 +1,44 @@
+{
+  "variables": {
+    "wifi_name":     "{{ env `WIFI_NAME` }}",
+    "wifi_password": "{{ env `WIFI_PASS` }}",
+    "ssh_pubkey":    "{{ env `SSH_PUBKEY` }}",
+    "home":          "{{env `HOME`}}"
+  },
+  "builders": [
+    {
+      "type": "arm-image",
+      "iso_url": "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-08-24/2020-08-20-raspios-buster-armhf-lite.zip",
+      "iso_checksum": "sha256:4522df4a29f9aac4b0166fbfee9f599dab55a997c855702bfe35329c13334668",
+      "target_image_size": 4294967296
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "apt-get update"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "wpa_passphrase \"{{user `wifi_name`}}\" \"{{user `wifi_password`}}\" | sed -e 's/#.*$//' -e '/^$/d' >> /etc/wpa_supplicant/wpa_supplicant.conf"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "touch /boot/ssh",
+        "install -d -o pi -g pi -m 700 /home/pi/.ssh",
+        "install -m 644 -o pi -g pi /dev/null /home/pi/.ssh/authorized_keys",
+        "echo '{{user `ssh_pubkey`}}' > /home/pi/.ssh/authorized_keys"
+      ]
+    },
+    {
+      "type": "shell",
+      "execute_command": "chmod +x {{ .Path }}; sudo {{ .Path }} -y",
+      "script": "/vagrant/pitrex-config.sh"
+    }
+  ]
+}

--- a/build/packer/pitrex-linux.json
+++ b/build/packer/pitrex-linux.json
@@ -4,6 +4,8 @@
     "wifi_password":  null,
     "ssh_pubkey":     "",
     "pitrex_git_url": "https://github.com/gtoal/pitrex.git",
+    "pitrex_prebuild": "https://github.com/gtoal/pitrex/releases/download/beta1/pitrex_beta1.tar.gz",
+    "basedir":        "/vagrant",
     "home":           "{{env `HOME`}}"
   },
   "builders": [
@@ -48,7 +50,23 @@
     {
       "type": "shell",
       "execute_command": "chmod +x {{ .Path }}; sudo {{ .Path }} -y -keephdmi",
-      "script": "/vagrant/pitrex-config.sh"
+      "script": "{{ user `basedir` }}/pitrex-config.sh"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "echo 'downloading and installing pitrex prebuilt baremetal system'",
+        "cd /tmp",
+        "mkdir -p /tmp/prebuild",
+        "wget -O /tmp/prebuild.tgz {{ user `pitrex_prebuild` }}",
+        "tar -zxf /tmp/prebuild.tgz -C /tmp/prebuild/",
+        "cp /tmp/prebuild/pitrex*/to_baremetal/roms/vectrex/* /boot/roms/",
+        "cp /tmp/prebuild/pitrex*/to_baremetal/ini/* /boot/ini/",
+        "cp /tmp/prebuild/pitrex*/to_baremetal/*.img /boot/",
+        "cp /tmp/prebuild/pitrex*/to_baremetal/*.pit /boot/",
+        "echo 'kernel=pitrex.img' >> /boot/config.txt",
+        "echo DONE"
+      ]
     },
     {
       "type": "shell",
@@ -71,9 +89,11 @@
     {
       "type": "shell",
       "inline": [
-        "echo 'building pitrex'",
+        "echo 'building & installing latest pitrex menu'",
         "cd /home/pi/src/pitrex",
-        "#TODO sudo -u pi make -f Makefile.raspbian",
+        "sudo -u pi make -f Makefile.baremetal loader",
+        "cp piTrexBoot/loader.pit /boot/",
+        "cp piTrexBoot/pitrex.img /boot/",
         "echo DONE"
       ]
     }

--- a/build/packer/pitrex-linux.json
+++ b/build/packer/pitrex-linux.json
@@ -1,9 +1,9 @@
 {
   "variables": {
-    "wifi_name":     "{{ env `WIFI_NAME` }}",
-    "wifi_password": "{{ env `WIFI_PASS` }}",
-    "ssh_pubkey":    "{{ env `SSH_PUBKEY` }}",
-    "home":          "{{env `HOME`}}"
+    "wifi_name":      null,
+    "wifi_password":  null,
+    "ssh_pubkey":     "",
+    "home":           "{{env `HOME`}}"
   },
   "builders": [
     {
@@ -17,18 +17,27 @@
     {
       "type": "shell",
       "inline": [
+        "echo 'wifi_name: {{user `wifi_name`}}'"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "echo 'running apt-get update'",
         "apt-get update"
       ]
     },
     {
       "type": "shell",
       "inline": [
+        "echo 'updating wpa_supplicant.conf'",
         "wpa_passphrase \"{{user `wifi_name`}}\" \"{{user `wifi_password`}}\" | sed -e 's/#.*$//' -e '/^$/d' >> /etc/wpa_supplicant/wpa_supplicant.conf"
       ]
     },
     {
       "type": "shell",
       "inline": [
+        "echo 'setting up ssh'",
         "touch /boot/ssh",
         "install -d -o pi -g pi -m 700 /home/pi/.ssh",
         "install -m 644 -o pi -g pi /dev/null /home/pi/.ssh/authorized_keys",
@@ -37,7 +46,7 @@
     },
     {
       "type": "shell",
-      "execute_command": "chmod +x {{ .Path }}; sudo {{ .Path }} -y",
+      "execute_command": "chmod +x {{ .Path }}; sudo {{ .Path }} -y -keephdmi",
       "script": "/vagrant/pitrex-config.sh"
     }
   ]

--- a/build/vagrant/provision-build-env.sh
+++ b/build/vagrant/provision-build-env.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# @script          provision.sh
+# @description     provisioning script that builds environment for
+#                  https://github.com/solo-io/packer-builder-arm-image
+#
+#                 By default, sets up environment, builds the plugin, and image
+##
+set -x
+# Set to false to disable auto building
+
+# Update the system
+sudo apt-get update -qq
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get \
+  -y \
+  --allow-downgrades \
+  --allow-remove-essential \
+  --allow-change-held-packages \
+ -qq \
+ -o Dpkg::Options::="--force-confdef" \
+ -o Dpkg::Options::="--force-confold" \
+  dist-upgrade
+
+# Provides the add-apt-repository script
+sudo apt-get install -y software-properties-common
+
+# Install required packages
+sudo apt-get install -y \
+    kpartx \
+    qemu-user-static \
+    git \
+    wget \
+    curl \
+    vim \
+    unzip \
+    gcc
+
+# Download specific Go version
+echo "Removing existing Go packages and installing Go"
+[[ -e /tmp/go ]] && rm -rf /tmp/go*
+sudo apt remove -y \
+  'golang-*'
+cd /tmp
+wget https://dl.google.com/go/go1.14.3.linux-amd64.tar.gz
+tar xf go1.14.3.linux-amd64.tar.gz
+sudo cp -r go /usr/lib/go-1.14
+rm -rf /tmp/go*
+
+# Set GO paths for vagrant user
+echo 'export GOROOT=/usr/lib/go-1.14
+export GOPATH=$HOME/work
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin' | tee -a /home/vagrant/.profile
+
+# Also set them while we work:
+export GOROOT=/usr/lib/go-1.14
+export GOPATH=$HOME/work
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+# Download and install packer
+[[ -e /tmp/packer ]] && rm -rf /tmp/packer*
+wget https://releases.hashicorp.com/packer/1.5.2/packer_1.5.2_linux_amd64.zip \
+    -q -O /tmp/packer_1.5.2_linux_amd64.zip
+cd /tmp
+unzip -u packer_1.5.2_linux_amd64.zip
+sudo cp packer /usr/local/bin
+rm -rf /tmp/packer*
+cd ..

--- a/build/vagrant/provision-build-image.sh
+++ b/build/vagrant/provision-build-image.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# @script          provision.sh
+# @description     provisioning script that builds environment for
+#                  https://github.com/solo-io/packer-builder-arm-image
+#
+#                 By default, sets up environment, builds the plugin, and image
+##
+set -x
+set -e
+# Set to false to disable auto building
+export PACKERFILE=${PACKERFILE:-build/packer/pitrex-linux.json}
+
+PLUGIN_DIR=${PLUGIN_DIR:-/root/.packer.d/plugins}
+sudo mkdir -p $PLUGIN_DIR
+sudo cp /vagrant/.packer.d/plugins/packer-builder-arm-image "$PLUGIN_DIR/"
+# Now build the image
+if sudo [[ ! -f "$PLUGIN_DIR/packer-builder-arm-image" ]]; then {
+    echo "Error: Plugin not found. Retry build."
+    exit
+} else {
+    echo "Attempting to build image"
+
+    PACKER_LOG=$(mktemp)
+
+    # If there is a custom json, try that one
+    # otherwise go with the default
+    if [[ -f /vagrant/${PACKERFILE} ]]; then {
+        sudo packer build /vagrant/${PACKERFILE} | tee ${PACKER_LOG}
+    } else {
+        if [[ -f $GOPATH/src/github.com/solo-io/packer-builder-arm-image/${PACKERFILE} ]]; then {
+            sudo packer build $GOPATH/src/github.com/solo-io/packer-builder-arm-image/${PACKERFILE} | tee ${PACKER_LOG}
+        } else {
+            echo "Error: packer build definition ${PACKERFILE} not found."
+            exit
+        }; fi
+    }; fi
+
+    BUILD_NAME=$(grep -Po "(?<=Build ').*(?=' finished.)" ${PACKER_LOG})
+    IMAGE_PATH=$(grep -Po "(?<=--> ${BUILD_NAME}: ).*" ${PACKER_LOG})
+    rm -f ${PACKER_LOG}
+
+    # If the new image is there, copy it out or throw an error
+    if [[ -f ${HOME}/${IMAGE_PATH} ]]; then {
+        sudo cp ${HOME}/${IMAGE_PATH} \
+            /vagrant/${IMAGE_PATH%/image}.img
+    } else {
+        echo "Error: Unable to find build artifact."
+        exit
+    }; fi
+    # safer than rm -r
+    sudo rm -f ${HOME}/${IMAGE_PATH} && 
+      sudo rmdir ${HOME}/${IMAGE_PATH%/image}
+}; fi

--- a/build/vagrant/provision-build-image.sh
+++ b/build/vagrant/provision-build-image.sh
@@ -10,12 +10,25 @@ set -x
 set -e
 # Set to false to disable auto building
 export PACKERFILE=${PACKERFILE:-build/packer/pitrex-linux.json}
+export VAR_FILE=${PACKER_VAR_FILE:-/vagrant/.packer.d/build-vars.json}
+
+export PACKER_LOG=10
+
+if [[ ! -f $VAR_FILE ]]; then
+  echo "Must specify $VAR_FILE containing:"
+  echo '{'
+  echo '  "wifi_name":  "<wifi ssid>",'
+  echo '  "wifi_password":  "<wifi wpa key>",'
+  echo '  "ssh_pubkey": "<ssh public key>"'
+  echo '}'
+  exit 1
+fi
 
 PLUGIN_DIR=${PLUGIN_DIR:-/root/.packer.d/plugins}
 sudo mkdir -p $PLUGIN_DIR
 sudo cp /vagrant/.packer.d/plugins/packer-builder-arm-image "$PLUGIN_DIR/"
 # Now build the image
-if sudo [[ ! -f "$PLUGIN_DIR/packer-builder-arm-image" ]]; then {
+if sudo test ! -f "$PLUGIN_DIR/packer-builder-arm-image"; then {
     echo "Error: Plugin not found. Retry build."
     exit
 } else {
@@ -25,16 +38,12 @@ if sudo [[ ! -f "$PLUGIN_DIR/packer-builder-arm-image" ]]; then {
 
     # If there is a custom json, try that one
     # otherwise go with the default
-    if [[ -f /vagrant/${PACKERFILE} ]]; then {
-        sudo packer build /vagrant/${PACKERFILE} | tee ${PACKER_LOG}
-    } else {
-        if [[ -f $GOPATH/src/github.com/solo-io/packer-builder-arm-image/${PACKERFILE} ]]; then {
-            sudo packer build $GOPATH/src/github.com/solo-io/packer-builder-arm-image/${PACKERFILE} | tee ${PACKER_LOG}
-        } else {
-            echo "Error: packer build definition ${PACKERFILE} not found."
-            exit
-        }; fi
-    }; fi
+    if [[ -f /vagrant/${PACKERFILE} ]]; then
+      sudo packer build -var-file="${VAR_FILE}" /vagrant/${PACKERFILE} | tee ${PACKER_LOG}
+    else
+      echo "Error: packer build definition ${PACKERFILE} not found."
+      exit 2
+    fi
 
     BUILD_NAME=$(grep -Po "(?<=Build ').*(?=' finished.)" ${PACKER_LOG})
     IMAGE_PATH=$(grep -Po "(?<=--> ${BUILD_NAME}: ).*" ${PACKER_LOG})

--- a/build/vagrant/provision-packer-builder-arm-image.sh
+++ b/build/vagrant/provision-packer-builder-arm-image.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# @script          provision.sh
+# @description     provisioning script that builds environment for
+#                  https://github.com/solo-io/packer-builder-arm-image
+#
+#                 By default, sets up environment, builds the plugin, and image
+##
+set -x
+# Set to false to disable auto building
+
+# Now ready to build the plugin
+mkdir -p $GOPATH/src/github.com/solo-io/
+cd $GOPATH/src/github.com/solo-io/
+
+# clean up potential residual files from previous builds
+rm -rf packer-builder-arm-image
+if [[ -z "${GIT_CLONE_URL}" ]]; then
+  git clone https://github.com/solo-io/packer-builder-arm-image
+else
+  git clone ${GIT_CLONE_URL} packer-builder-arm-image
+fi
+cd packer-builder-arm-image
+go build
+
+# Check if plugin built and copy into place
+if [[ ! -f packer-builder-arm-image ]]; then
+  echo "Error Plugin failed to build."
+  exit
+else
+  mkdir -p /vagrant/.packer.d/plugins/
+  cp packer-builder-arm-image /vagrant/.packer.d/plugins/
+fi

--- a/pitrex-config.sh
+++ b/pitrex-config.sh
@@ -60,6 +60,7 @@ until [ -z "$1" ]
 do
  case "$1" in
 	"-configonly")	CONFIGONLY=1 ;;
+	"-keephdmi")	  KEEPHDMI=1 ;;
 	"-y")		YESTOALL=1 ;;
 	*)		echo "Invalid option: $1"; exit 1 ;;
  esac
@@ -171,7 +172,7 @@ else
  YN="y";
 fi
 
-if [ "$YN" == "y" ] ; then
+if [ "$YN" == "y" -a -z $KEEPHDMI ] ; then
 sed -i '/^exit 0$/i'' \
 #Disable HDMI/Composite video output:\
 tvservice \-o' /etc/rc.local


### PR DESCRIPTION
This PR adds an automated build, steps detailed in README.imgbuild

It's based around https://github.com/solo-io/packer-builder-arm-image

Currently it's more of a time-saving system than an img that's suitable for non-devs, but it should form the basis of that when we're ready.

It sets up:
- Wifi
- SSH
- installs build dependencies for pitrex

The process should be pretty straightforward to go through once you have a working Vagrant environment.

You need to specify Wifi details in .packer.d/build-vars.json:

```
{
  "wifi_name":     "<ssid>",
  "wifi_password": "<password>",
  "ssh_pubkey":    "<your ssh public key, this is optional>"
}
```

I've also now added the baremetal pitrex.img menu, based on  @ComputerNerdKev feedback in pitrex-dev 👍 